### PR TITLE
Use CXShim instead of hardcoded Combine implementation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,6 @@ let package = Package(
   
   name: "SwiftWebUI",
   
-  platforms: [
-    .macOS(.v10_15), .iOS(.v13)
-  ],
-  
   products: [
     .library   (name: "SwiftWebUI", targets: [ "SwiftWebUI" ]),
     .executable(name: "HolyCow",    targets: [ "HolyCow"    ])
@@ -35,3 +31,36 @@ let package = Package(
     .target(name: "HolyCow", dependencies: [ "SwiftWebUI" ])
   ]
 )
+
+enum CombineImplementation {
+
+  case combine, combineX, openCombine
+
+  static var `default`: CombineImplementation {
+    #if canImport(Combine)
+    return .combine
+    #else
+    return .combineX
+    #endif
+  }
+
+  init?(_ description: String) {
+    let desc = description.lowercased().filter { $0.isLetter }
+    switch desc {
+    case "combine":     self = .combine
+    case "combinex":    self = .combineX
+    case "opencombine": self = .openCombine
+    default:            return nil
+    }
+  }
+}
+
+import Foundation
+
+let env = ProcessInfo.processInfo.environment
+let implkey = "CX_COMBINE_IMPLEMENTATION"
+let combineImpl = env[implkey].flatMap(CombineImplementation.init) ?? .default
+
+if combineImpl == .combine {
+  package.platforms = [.macOS(.v10_15), .iOS(.v13)]
+}

--- a/Package.swift
+++ b/Package.swift
@@ -2,17 +2,6 @@
 
 import PackageDescription
 
-#if canImport(Combine)
-  let extraPackages     : [ PackageDescription.Package.Dependency ] = []
-  let extraDependencies : [ Target.Dependency ] = []
-#else
-  let extraPackages     : [ PackageDescription.Package.Dependency ] = [
-    .package(url: "https://github.com/broadwaylamb/OpenCombine.git",
-             from: "0.5.0")
-  ]
-  let extraDependencies : [ Target.Dependency ] = [ "OpenCombine" ]
-#endif
-
 let package = Package(
   
   name: "SwiftWebUI",
@@ -32,15 +21,17 @@ let package = Package(
     .package(url: "https://github.com/SwiftWebResources/SemanticUI-Swift.git",
              from: "2.3.4"),
     .package(url: "https://github.com/wickwirew/Runtime.git",
-             from: "2.1.1")
-  ] + extraPackages,
+             from: "2.1.1"),
+    .package(url: "https://github.com/cx-org/CombineX.git",
+             from: "0.1.0")
+  ],
   
   targets: [
     .target(name: "SwiftWebUI",
             dependencies: [ 
                 "NIO", "NIOHTTP1", "NIOConcurrencyHelpers", 
-                "Runtime", "SemanticUI" 
-            ] + extraDependencies),
+                "Runtime", "SemanticUI", "CXShim"
+            ]),
     .target(name: "HolyCow", dependencies: [ "SwiftWebUI" ])
   ]
 )

--- a/README.md
+++ b/README.md
@@ -77,45 +77,9 @@ Use it to learn more about SwiftUI and its inner workings.
 
 ## Requirements
 
-Update 2019-07-08: There are three options to run SwiftWebUI:
+- Swift 5.1
 
-### macOS Catalina
-
-One can use a
-[macOS Catalina](https://www.apple.com/macos/catalina-preview/)
-installation to run SwiftWebUI.
-Make sure that the Catalina version matches your Xcode 11 beta! (“Swift ABI” 🤦‍♀️)
-
-Fortunately it is really easy to
-[install Catalina on a separate APFS volume](https://support.apple.com/en-us/HT208891).
-And an installation of
-[Xcode 11](https://developer.apple.com/xcode/)
-is required to get the new Swift 5.1 features SwiftUI makes heavy use of.
-Got that? Very well!
-
-> Why is Catalina required? SwiftUI makes use of new Swift 5.1 runtime features
-> (e.g. opaque result types).
-> Those features are not available in the Swift 5 runtime that ships with 
-> Mojave.
-> (another reason is the use of Combine which is only available in Catalina, 
-> though that part could be fixed using
-> [OpenCombine](https://github.com/broadwaylamb/OpenCombine))
-
-### tuxOS
-
-SwiftWebUI now runs on Linux using
-[OpenCombine](https://github.com/broadwaylamb/OpenCombine) (also works without
-that, but then some things don't work, e.g. `NavigationView`).
-
-A [Swift 5.1 snapshot](https://swift.org/download/#snapshots) is required.
-We also provide a Docker image containing a 5.1 snapshot over here:
-[helje5/swift](https://cloud.docker.com/repository/docker/helje5/swift/tags).
-
-### Mojave
-
-The Xcode 11beta iOS 13 simulators do run on Mojave.
-You might be able to run SwiftWebUI within an iOS app.
-
+Note Combine requires macOS Catalina. For Linux or lower version macOS, open-source Combine is used. See [Combine Compatible Package](https://github.com/cx-org/CombineX/wiki/Combine-Compatible-Package)
 
 ## SwiftWebUI Hello World
 

--- a/Sources/SwiftWebUI/Misc/NoCombine.swift
+++ b/Sources/SwiftWebUI/Misc/NoCombine.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Helge Heß. All rights reserved.
 //
 
-#if !canImport(Combine) && !canImport(OpenCombine)
+#if !canImport(CXShim)
 
 // TODO: This needs more work. Just the basics to get synchronous event emitters
 //       working w/o Combine.
@@ -126,4 +126,4 @@ public extension Publisher {
   }
 }
 
-#endif // !canImport(Combine)
+#endif // !canImport(CXShim)

--- a/Sources/SwiftWebUI/Properties/EnvironmentObject.swift
+++ b/Sources/SwiftWebUI/Properties/EnvironmentObject.swift
@@ -6,11 +6,7 @@
 //  Copyright © 2019 Helge Heß. All rights reserved.
 //
 
-#if canImport(Combine)
-  import Combine
-#elseif canImport(OpenCombine)
-  import OpenCombine
-#endif
+import CXShim
 
 @propertyWrapper
 public struct EnvironmentObject<O: ObservableObject>: _StateType {

--- a/Sources/SwiftWebUI/Properties/ObservableObject.swift
+++ b/Sources/SwiftWebUI/Properties/ObservableObject.swift
@@ -7,11 +7,7 @@
 //
 
 // FIXME: Combine requires 10.15, maybe provide a simple alternative
-#if canImport(Combine)
-  import Combine
-#elseif canImport(OpenCombine)
-  import OpenCombine
-#endif
+import CXShim
 
 public protocol ObservableObject: AnyObject, DynamicViewProperty, Identifiable {
   

--- a/Sources/SwiftWebUI/Properties/ObservedObject.swift
+++ b/Sources/SwiftWebUI/Properties/ObservedObject.swift
@@ -6,11 +6,7 @@
 //  Copyright © 2019 Helge Heß. All rights reserved.
 //
 
-#if canImport(Combine)
-  import Combine
-#elseif canImport(OpenCombine)
-  import OpenCombine
-#endif
+import CXShim
 
 @propertyWrapper
 public struct ObservedObject<O: ObservableObject>: _StateType {

--- a/Sources/SwiftWebUI/Properties/SubscriptionView.swift
+++ b/Sources/SwiftWebUI/Properties/SubscriptionView.swift
@@ -6,8 +6,7 @@
 //  Copyright © 2019 Helge Heß. All rights reserved.
 //
 
-#if canImport(Combine)
-import Combine
+import CXShim
 
 public extension View {
   
@@ -131,5 +130,3 @@ fileprivate struct MySubView : View {
   }
 }
 #endif
-
-#endif // canImport(Combine)

--- a/Sources/SwiftWebUI/Views/Navigation/NavigationContext.swift
+++ b/Sources/SwiftWebUI/Views/Navigation/NavigationContext.swift
@@ -6,11 +6,7 @@
 //  Copyright © 2019 Helge Heß. All rights reserved.
 //
 
-#if canImport(Combine)
-  import Combine
-#elseif canImport(OpenCombine)
-  import OpenCombine
-#endif
+import CXShim
 
 final class NavigationContext: ObservableObject {
   


### PR DESCRIPTION
See [Combine Compatible Package](https://github.com/cx-org/CombineX/wiki/Combine-Compatible-Package)

## Advantage

- Current clients remains unaffected.
- Apple's Combine is used by default whenever possible. No additional dependency is introduced.
- OpenCombine is still available.
- The package now support lower version macOS/iOS (use open-source Combine).
- Your clients can still use open-source Combine for macOS Catalina if they want.
- No matter which Combine implementation you client choose, the package adapt to it automatically.