### PR TITLE
Added support for View optionals, fixing @ViewBuilder conditionals.

### DIFF
--- a/Sources/SwiftWebUI/Views/View.swift
+++ b/Sources/SwiftWebUI/Views/View.swift
@@ -13,3 +13,10 @@ public protocol View {
   var body : Self.Body { get }
 
 }
+
+//support for optional Views, mainly for @ViewBuilder convenience
+extension Optional : View where Wrapped : View {
+    public var body: EmptyView {
+        EmptyView()
+    }
+}

--- a/Sources/SwiftWebUI/Views/ViewBuilder.swift
+++ b/Sources/SwiftWebUI/Views/ViewBuilder.swift
@@ -19,9 +19,7 @@
 
 public extension ViewBuilder {
   
-  static func buildIf<V: View>(_ content: V)  -> V  { return content }
-  //static func buildIf<V: View>(_ content: V?) -> V? { return content }
-    // This one still doesn't work!
+  static func buildIf<V: View>(_ content: V?) -> V? { return content }
   
   static func buildEither<T: View, F: View>(first: T)
               -> ConditionalContent<T, F>

--- a/Sources/SwiftWebUI/VirtualDOM/Components/ComponentReflection.swift
+++ b/Sources/SwiftWebUI/VirtualDOM/Components/ComponentReflection.swift
@@ -128,6 +128,10 @@ extension ComponentTypeInfo {
       return nil
     }
     guard structInfo.kind == .struct else {
+      if structInfo.kind == .optional {
+        self = .static
+        return
+      }
       print("Only structs allowed as View:", viewType)
       assertionFailure("currently only supporting structs for Views")
       return nil


### PR DESCRIPTION
Previously conditionals had to have a trailing "else {...}" at the end because of lack of optional support from the View protocol.
This fix will introduce View optionals and make the behavior more like SwiftUI's View.

**Note:**
I had to add an optional check inside ComponentReflection.swift, I'm not 100% sure of the inner workings of this file but this doesn't seem to be causing any conflicts.